### PR TITLE
additions to knot vector class

### DIFF
--- a/src/baf/basis_function.cc
+++ b/src/baf/basis_function.cc
@@ -41,17 +41,10 @@ int baf::BasisFunction::GetDegree() const {
 }
 
 bool baf::BasisFunction::IsCoordinateInSupport(ParamCoord param_coord) const {
-  return knotVector_.IsInKnotVectorRange(param_coord)
-      && (IsCoordinateInSupportSpan(param_coord) || IsCoordinateSpecialCaseWithLastKnot(param_coord));
+  return knotVector_.IsInKnotVectorRange(param_coord) && IsCoordinateInSupportSpan(param_coord);
 }
 
 bool baf::BasisFunction::IsCoordinateInSupportSpan(ParamCoord param_coord) const {
   auto span = knotVector_.GetKnotSpan(param_coord);
   return !(span < start_of_support_ || span >= start_of_support_ + degree_ + 1);
-}
-
-bool baf::BasisFunction::IsCoordinateSpecialCaseWithLastKnot(ParamCoord param_coord) const {
-  return util::NumericSettings<double>::AreEqual(param_coord.get(), knotVector_.GetLastKnot().get()) &&
-      util::NumericSettings<double>::AreEqual(knotVector_.GetLastKnot().get(),
-                                              knotVector_.GetKnot(start_of_support_ + degree_ + 1).get());
 }

--- a/src/baf/basis_function.h
+++ b/src/baf/basis_function.h
@@ -54,9 +54,6 @@ class BasisFunction {
   // Check if parametric coordinate is in the range of knot spans where the basis function is defined to be non-zero.
   bool IsCoordinateInSupportSpan(ParamCoord param_coord) const;
 
-  // Check if parametric coordinate is last knot of knot vector and last knot of basis function support range.
-  bool IsCoordinateSpecialCaseWithLastKnot(ParamCoord param_coord) const;
-
   KnotVector knotVector_;
   int degree_;
   uint64_t start_of_support_;

--- a/src/baf/knot_vector.cc
+++ b/src/baf/knot_vector.cc
@@ -94,6 +94,14 @@ baf::KnotVector::ConstKnotIterator baf::KnotVector::end() const {
   return knots_.end();
 }
 
+baf::KnotVector::KnotIterator baf::KnotVector::begin() {
+  return knots_.begin();
+}
+
+baf::KnotVector::KnotIterator baf::KnotVector::end() {
+  return knots_.end();
+}
+
 bool baf::KnotVector::IsInKnotVectorRange(ParamCoord param_coord) const {
   return param_coord.get() >= knots_.front().get() && param_coord.get() <= knots_.back().get();
 }

--- a/src/baf/knot_vector.cc
+++ b/src/baf/knot_vector.cc
@@ -81,6 +81,9 @@ ParamCoord baf::KnotVector::GetLastKnot() const {
 }
 
 int64_t baf::KnotVector::GetKnotSpan(ParamCoord param_coord) const {
+  if (!IsInKnotVectorRange(param_coord)) {
+    throw std::runtime_error("The parametric coordinate is outside the knot vector range.");
+  }
   return util::NumericSettings<double>::AreEqual(param_coord.get(), knots_.back().get()) ?
       std::lower_bound(knots_.begin(), knots_.end(), param_coord) - knots_.begin() - 1 :
       std::upper_bound(knots_.begin(), knots_.end(), param_coord) - knots_.begin() - 1;

--- a/src/baf/knot_vector.cc
+++ b/src/baf/knot_vector.cc
@@ -81,9 +81,6 @@ ParamCoord baf::KnotVector::GetLastKnot() const {
 }
 
 int64_t baf::KnotVector::GetKnotSpan(ParamCoord param_coord) const {
-  if (!IsInKnotVectorRange(param_coord)) {
-    throw std::runtime_error("The parametric coordinate is outside the knot vector range.");
-  }
   return util::NumericSettings<double>::AreEqual(param_coord.get(), knots_.back().get()) ?
       std::lower_bound(knots_.begin(), knots_.end(), param_coord) - knots_.begin() - 1 :
       std::upper_bound(knots_.begin(), knots_.end(), param_coord) - knots_.begin() - 1;

--- a/src/baf/knot_vector.cc
+++ b/src/baf/knot_vector.cc
@@ -30,6 +30,15 @@ baf::KnotVector::KnotVector(std::initializer_list<ParamCoord> knots) : knots_(kn
 
 baf::KnotVector::KnotVector(ConstKnotIterator begin, ConstKnotIterator end) : knots_(std::vector<ParamCoord>(begin,
                                                                                                              end)) {}
+
+baf::KnotVector baf::KnotVector::operator-(const baf::KnotVector &rhs) const {
+  std::vector<ParamCoord> differences;
+  for(int knot = 0; knot < this->GetNumberOfKnots(); knot++) {
+    differences.push_back(ParamCoord{knots_[knot] - rhs.knots_[knot]});
+  }
+  return baf::KnotVector(differences);
+}
+
 baf::KnotVector &baf::KnotVector::operator=(const baf::KnotVector &other) {
   knots_ = other.knots_;
   return *this;

--- a/src/baf/knot_vector.h
+++ b/src/baf/knot_vector.h
@@ -30,6 +30,7 @@ namespace baf {
 class KnotVector {
  public:
   using ConstKnotIterator = std::vector<ParamCoord>::const_iterator;
+  using KnotIterator = std::vector<ParamCoord>::iterator;
 
   KnotVector() = default;
   KnotVector(const KnotVector &knotVector);
@@ -55,6 +56,9 @@ class KnotVector {
 
   ConstKnotIterator begin() const;
   ConstKnotIterator end() const;
+
+  KnotIterator begin();
+  KnotIterator end();
 
   bool IsInKnotVectorRange(ParamCoord param_coord) const;
   bool IsLastKnot(ParamCoord param_coord) const;

--- a/src/baf/knot_vector.h
+++ b/src/baf/knot_vector.h
@@ -40,6 +40,7 @@ class KnotVector {
 
   virtual ~KnotVector() = default;
 
+  KnotVector operator -(const KnotVector& rhs) const;
   KnotVector &operator=(const KnotVector &other);
   KnotVector &operator=(const KnotVector &&other);
   // Check if absolute distance between all knots is smaller than the epsilon defined in

--- a/src/spl/CMakeLists.txt
+++ b/src/spl/CMakeLists.txt
@@ -15,7 +15,8 @@
 
 set(SOURCES
         parameter_space.cc
-        square_generator.cc)
+        square_generator.cc
+        spline.h)
 
 add_library(splinelibspl SHARED ${SOURCES})
 target_include_directories(splinelibspl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/src/spl/b_spline.h
+++ b/src/spl/b_spline.h
@@ -31,6 +31,7 @@ class BSpline : public Spline<DIM> {
   std::vector<double> EvaluateDerivative(std::array<ParamCoord, DIM> param_coord,
                                          const std::vector<int> &dimensions,
                                          std::array<int, DIM> derivative) const override {
+    this->ThrowIfParametricCoordinateOutsideKnotVectorRange(param_coord);
     auto basis_function_values = EvaluateAllNonZeroBasisFunctionDerivatives(param_coord, derivative);
     std::vector<double> evaluated_point(dimensions.size(), 0);
     for (int i = 0; i < dimensions.size(); ++i) {

--- a/src/spl/nurbs.h
+++ b/src/spl/nurbs.h
@@ -36,6 +36,7 @@ class NURBS : public Spline<DIM> {
   std::vector<double> EvaluateDerivative(std::array<ParamCoord, DIM> param_coord,
                                          const std::vector<int> &dimensions,
                                          std::array<int, DIM> derivative) const override {
+    this->ThrowIfParametricCoordinateOutsideKnotVectorRange(param_coord);
     if (derivative == std::array<int, DIM>{0}) {
       return this->Evaluate(param_coord, dimensions);
     }

--- a/src/spl/spline.h
+++ b/src/spl/spline.h
@@ -46,6 +46,7 @@ class Spline {
   }
 
   std::vector<double> Evaluate(std::array<ParamCoord, DIM> param_coord, const std::vector<int> &dimensions) const {
+    ThrowIfParametricCoordinateOutsideKnotVectorRange(param_coord);
     auto basis_function_values = EvaluateAllNonZeroBasisFunctions(param_coord);
     std::vector<double> evaluated_point(dimensions.size(), 0);
     for (int i = 0; i < dimensions.size(); ++i) {
@@ -130,6 +131,15 @@ class Spline {
   }
 
  protected:
+  void ThrowIfParametricCoordinateOutsideKnotVectorRange(std::array<ParamCoord, DIM> param_coord) const {
+    for (int dim = 0; dim < DIM; dim++) {
+      if (!this->GetKnotVector(dim).IsInKnotVectorRange(param_coord[dim])) {
+        throw std::runtime_error("The parametric coordinate is outside the knot vector range.");
+      }
+    }
+
+  }
+
   double ComputeWeightedSum(const std::vector<double> &basis_function_values,
                             std::vector<double> control_point_values) const {
     std::transform(basis_function_values.begin(),

--- a/src/spl/spline.h
+++ b/src/spl/spline.h
@@ -143,7 +143,6 @@ class Spline {
         throw std::range_error(message.str());
       }
     }
-
   }
 
   double ComputeWeightedSum(const std::vector<double> &basis_function_values,

--- a/test/b_spline_test.cc
+++ b/test/b_spline_test.cc
@@ -89,6 +89,22 @@ TEST_F(ABSpline, Returns0_325For2_25Dim1AndDer1) {
   ASSERT_THAT(b_spline->EvaluateDerivative({ParamCoord{2.25}}, {1}, {1})[0], DoubleEq(0.325));
 }
 
+TEST_F(ABSpline, ThrowsExceptionForEvaluationAt6_0) {
+  ASSERT_THROW(b_spline->Evaluate({ParamCoord{6.0}}, {0}), std::runtime_error);
+}
+
+TEST_F(ABSpline, ThrowsExceptionForEvaluationAtMinus1_0) {
+  ASSERT_THROW(b_spline->Evaluate({ParamCoord{-1.0}}, {0}), std::runtime_error);
+}
+
+TEST_F(ABSpline, ThrowsExceptionForDerivativeEvaluationAt6_0) {
+  ASSERT_THROW(b_spline->EvaluateDerivative({ParamCoord{6.0}}, {0}, {1}), std::runtime_error);
+}
+
+TEST_F(ABSpline, ThrowsExceptionForDerivativeEvaluationAtMinus1_0) {
+  ASSERT_THROW(b_spline->EvaluateDerivative({ParamCoord{-1.0}}, {0}, {1}), std::runtime_error);
+}
+
 TEST_F(ABSpline, ReturnsCorrectNumberOfElements) {
   ASSERT_THAT(b_spline->GetElementList().size(), 5);
 }

--- a/test/knot_vector_test.cc
+++ b/test/knot_vector_test.cc
@@ -24,7 +24,7 @@ using testing::DoubleEq;
 class AKnotVector : public Test {
  public:
   AKnotVector() : knot_vector_({ParamCoord{0.0}, ParamCoord{0.0}, ParamCoord{0.0}, ParamCoord{0.5}, ParamCoord{0.5},
-                                   ParamCoord{0.75}, ParamCoord{1.0}, ParamCoord{1.0}, ParamCoord{1.0}}) {}
+                                ParamCoord{0.75}, ParamCoord{1.0}, ParamCoord{1.0}, ParamCoord{1.0}}) {}
 
  protected:
   baf::KnotVector knot_vector_;
@@ -116,11 +116,19 @@ TEST_F(AKnotVector, CanBeAssigned) {
   ASSERT_THAT(knotVector, Eq(this->knot_vector_));
 }
 
-TEST_F(AKnotVector, CanBe) {
+TEST_F(AKnotVector, CanBeSubtracted) {
   ParamCoord zero = ParamCoord{0.0};
   baf::KnotVector knotVectorOfZeros = baf::KnotVector({zero, zero, zero, zero, zero, zero, zero, zero, zero});
   this->knot_vector_ = this->knot_vector_ - this->knot_vector_;
   ASSERT_THAT(this->knot_vector_, Eq(knotVectorOfZeros));
+}
+
+TEST_F(AKnotVector, CanBeUsedWithRangeBasedForLoop) {
+  double sum = 0;
+  for (auto &knot : knot_vector_) {
+    sum += knot.get();
+  }
+  ASSERT_THAT(sum, DoubleEq(4.75));
 }
 
 TEST_F(AKnotVector, CanBeMovedInAssignment) {

--- a/test/knot_vector_test.cc
+++ b/test/knot_vector_test.cc
@@ -116,6 +116,13 @@ TEST_F(AKnotVector, CanBeAssigned) {
   ASSERT_THAT(knotVector, Eq(this->knot_vector_));
 }
 
+TEST_F(AKnotVector, CanBe) {
+  ParamCoord zero = ParamCoord{0.0};
+  baf::KnotVector knotVectorOfZeros = baf::KnotVector({zero, zero, zero, zero, zero, zero, zero, zero, zero});
+  this->knot_vector_ = this->knot_vector_ - this->knot_vector_;
+  ASSERT_THAT(this->knot_vector_, Eq(knotVectorOfZeros));
+}
+
 TEST_F(AKnotVector, CanBeMovedInAssignment) {
   baf::KnotVector knotVector;
   knotVector = baf::KnotVector({ParamCoord{0.0}, ParamCoord{0.25}, ParamCoord{0.5}});

--- a/test/knot_vector_test.cc
+++ b/test/knot_vector_test.cc
@@ -123,12 +123,23 @@ TEST_F(AKnotVector, CanBeSubtracted) {
   ASSERT_THAT(this->knot_vector_, Eq(knotVectorOfZeros));
 }
 
-TEST_F(AKnotVector, CanBeUsedWithRangeBasedForLoop) {
+TEST_F(AKnotVector, CanBeUsedWithConstRangeBasedForLoop) {
   double sum = 0;
-  for (auto &knot : knot_vector_) {
+  for (const auto &knot : knot_vector_) {
     sum += knot.get();
   }
   ASSERT_THAT(sum, DoubleEq(4.75));
+}
+
+TEST_F(AKnotVector, CanBeUsedWithNonConstRangeBasedForLoop) {
+  double sum = 0;
+  for (auto &knot : knot_vector_) {
+    knot = ParamCoord{4.0};
+  }
+  for (const auto &knot : knot_vector_) {
+    sum += knot.get();
+  }
+  ASSERT_THAT(sum, DoubleEq(36));
 }
 
 TEST_F(AKnotVector, CanBeMovedInAssignment) {


### PR DESCRIPTION
* fixes issue 41: implement operator-, _but not using it in operator==_
* fixes issue 40: implement non-const versions of begin() and end() for knot vector
* fixes issue 44: add test for const and non-const range-based for loop in knot vector tests
* fixes issue 58: throw exception if spline is evaluated outside of knot vector range, _but check condition in b-spline->/nurbs->evaluateDerivative() and not in spline->evaluateDerivative()_