### PR TITLE
Changes the KnotVectors to shared pointers.

### DIFF
--- a/src/baf/zero_degree_b_spline_basis_function.cc
+++ b/src/baf/zero_degree_b_spline_basis_function.cc
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License along w
 
 #include "numeric_settings.h"
 
-baf::ZeroDegreeBSplineBasisFunction::ZeroDegreeBSplineBasisFunction(const KnotVector &knot_vector,
+baf::ZeroDegreeBSplineBasisFunction::ZeroDegreeBSplineBasisFunction(const baf::KnotVector &knot_vector,
                                                                     uint64_t start_of_support)
     : BasisFunction(knot_vector, 0, start_of_support) {}
 

--- a/src/baf/zero_degree_b_spline_basis_function.h
+++ b/src/baf/zero_degree_b_spline_basis_function.h
@@ -23,7 +23,7 @@ You should have received a copy of the GNU Lesser General Public License along w
 namespace baf {
 class ZeroDegreeBSplineBasisFunction : public baf::BasisFunction {
  public:
-  ZeroDegreeBSplineBasisFunction(const KnotVector &knot_vector, uint64_t start_of_support);
+  ZeroDegreeBSplineBasisFunction(const baf::KnotVector &knot_vector, uint64_t start_of_support);
 
  protected:
   double EvaluateOnSupport(ParamCoord param_coord) const override;

--- a/src/spl/b_spline.h
+++ b/src/spl/b_spline.h
@@ -24,7 +24,7 @@ namespace spl {
 template<int DIM>
 class BSpline : public Spline<DIM> {
  public:
-  BSpline(const std::array<baf::KnotVector, DIM> &knot_vector,
+  BSpline(std::shared_ptr<std::array<baf::KnotVector, DIM>> knot_vector,
           std::array<int, DIM> degree,
           const std::vector<baf::ControlPoint> &control_points) : Spline<DIM>(knot_vector, degree, control_points) {}
 

--- a/src/spl/nurbs.h
+++ b/src/spl/nurbs.h
@@ -26,7 +26,7 @@ namespace spl {
 template<int DIM>
 class NURBS : public Spline<DIM> {
  public:
-  NURBS(const std::array<baf::KnotVector, DIM> &knot_vector,
+  NURBS(std::shared_ptr<std::array<baf::KnotVector, DIM >> knot_vector,
         std::array<int, DIM> degree,
         const std::vector<baf::ControlPoint> &control_points, std::vector<double> weights) : Spline<DIM>(
       knot_vector,
@@ -124,7 +124,8 @@ class NURBS : public Spline<DIM> {
   }
 
   std::unique_ptr<spl::BSpline<DIM>> GetBSpline(std::vector<baf::ControlPoint> controlPoints) const {
-    return std::make_unique<spl::BSpline<DIM>>(GetKnotVectors(), GetDegrees(), controlPoints);
+    std::shared_ptr<std::array<baf::KnotVector, DIM>> knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, DIM>>(GetKnotVectors());
+    return std::make_unique<spl::BSpline<DIM>>(knot_vector_ptr, GetDegrees(), controlPoints);
   }
 
   double GetSum(std::array<ParamCoord, DIM> param_coord) const {

--- a/src/spl/spline.h
+++ b/src/spl/spline.h
@@ -34,12 +34,12 @@ class Spline {
  public:
   virtual ~Spline() = default;
 
-  Spline(const std::array<baf::KnotVector, DIM> &knot_vector,
+  Spline(std::shared_ptr<std::array<baf::KnotVector, DIM>> knot_vector,
          std::array<int, DIM> degree,
          const std::vector<baf::ControlPoint> &control_points)
       : dim(control_points[0].GetDimension()) {
     for (int i = 0; i < DIM; ++i) {
-      parameter_space_[i] = ParameterSpace(knot_vector[i], degree[i]);
+      parameter_space_[i] = ParameterSpace(knot_vector->at(i), degree[i]);
     }
     for (auto &&cp : control_points) {
       for (int i = 0; i < dim; ++i) {

--- a/src/spl/square_generator.cc
+++ b/src/spl/square_generator.cc
@@ -14,20 +14,23 @@ You should have received a copy of the GNU Lesser General Public License along w
 
 #include "square_generator.h"
 
-spl::SquareGenerator::SquareGenerator() : knot_vectors_(
+spl::SquareGenerator::SquareGenerator() {
     // zero_ and one_ should be used here
-    {baf::KnotVector{ParamCoord{0}, ParamCoord{0}, ParamCoord{0}, ParamCoord{1}, ParamCoord{1}, ParamCoord{1}},
-     baf::KnotVector{{ParamCoord{0}, ParamCoord{0}, ParamCoord{0}, ParamCoord{1}, ParamCoord{1}, ParamCoord{1}}}}),
-                                          degrees_({2, 2}),
-                                          control_points_({baf::ControlPoint(std::vector<double>({-1.0, -1.0})),
-                                                           baf::ControlPoint(std::vector<double>({0.0, -1.0})),
-                                                           baf::ControlPoint(std::vector<double>({1.0, -1.0})),
-                                                           baf::ControlPoint(std::vector<double>({-1.0, 0.0})),
-                                                           baf::ControlPoint(std::vector<double>({0.0, 0.0})),
-                                                           baf::ControlPoint(std::vector<double>({1.0, 0.0})),
-                                                           baf::ControlPoint(std::vector<double>({-1.0, 1.0})),
-                                                           baf::ControlPoint(std::vector<double>({0.0, 1.0})),
-                                                           baf::ControlPoint(std::vector<double>({1.0, 1.0}))}) {}
+    knot_vectors_ =
+        {baf::KnotVector{ParamCoord{0}, ParamCoord{0}, ParamCoord{0}, ParamCoord{1}, ParamCoord{1}, ParamCoord{1}},
+         {baf::KnotVector{{ParamCoord{0}, ParamCoord{0}, ParamCoord{0}, ParamCoord{1}, ParamCoord{1}, ParamCoord{1}}}}};
+    degrees_ = {2,2};
+    control_points_ = {baf::ControlPoint(std::vector<double>({-1.0, -1.0})),
+                       baf::ControlPoint(std::vector<double>({0.0, -1.0})),
+                       baf::ControlPoint(std::vector<double>({1.0, -1.0})),
+                       baf::ControlPoint(std::vector<double>({-1.0, 0.0})),
+                       baf::ControlPoint(std::vector<double>({0.0, 0.0})),
+                       baf::ControlPoint(std::vector<double>({1.0, 0.0})),
+                       baf::ControlPoint(std::vector<double>({-1.0, 1.0})),
+                       baf::ControlPoint(std::vector<double>({0.0, 1.0})),
+                       baf::ControlPoint(std::vector<double>({1.0, 1.0}))};
+    knot_vector_ptr_ = std::make_shared<std::array<baf::KnotVector, 2>>(knot_vectors_);
+};
 
 spl::SquareGenerator::SquareGenerator(int degree, int number_of_knots) : degrees_({degree, degree}) {
   std::vector<ParamCoord> knots;
@@ -41,6 +44,7 @@ spl::SquareGenerator::SquareGenerator(int degree, int number_of_knots) : degrees
     knots.push_back(one_);
   }
   knot_vectors_ = {baf::KnotVector(knots), baf::KnotVector(knots)};
+  knot_vector_ptr_ = std::make_shared<std::array<baf::KnotVector, 2>>(knot_vectors_);
 
   for (int dimension1 = 0; dimension1 < number_of_knots - degree - 1; dimension1++) {
     for (int dimension2 = 0; dimension2 < number_of_knots - degree - 1; dimension2++) {
@@ -51,5 +55,5 @@ spl::SquareGenerator::SquareGenerator(int degree, int number_of_knots) : degrees
 }
 
 std::unique_ptr<spl::BSpline<2>> spl::SquareGenerator::CreateSquare() const {
-  return std::make_unique<BSpline<2>>(knot_vectors_, degrees_, control_points_);
+  return std::make_unique<BSpline<2>>(knot_vector_ptr_, degrees_, control_points_);
 }

--- a/src/spl/square_generator.h
+++ b/src/spl/square_generator.h
@@ -30,11 +30,12 @@ class SquareGenerator {
   std::unique_ptr<BSpline<2>> CreateSquare() const;
 
  private:
-  std::array<baf::KnotVector, 2> knot_vectors_;
+  std::array<baf::KnotVector, 2 > knot_vectors_;
   std::array<int, 2> degrees_;
   std::vector<baf::ControlPoint> control_points_;
   ParamCoord one_{1};
   ParamCoord zero_{0};
+  std::shared_ptr<std::array<baf::KnotVector, 2>> knot_vector_ptr_;
 };
 }  // namespace spl
 

--- a/test/2d_b_spline_test.cc
+++ b/test/2d_b_spline_test.cc
@@ -39,11 +39,13 @@ class A2DBSpline : public Test {
         baf::ControlPoint(std::vector<double>({0.0, 1.0, 0.0})),
         baf::ControlPoint(std::vector<double>({1.0, 1.0, 0.0}))
     };
-    b_spline = std::make_unique<spl::BSpline<2>>(knot_vector, degree, control_points);
+    knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 2>>(knot_vector);
+    b_spline = std::make_unique<spl::BSpline<2>>(knot_vector_ptr, degree, control_points);
   }
 
  protected:
   std::unique_ptr<spl::BSpline<2>> b_spline;
+  std::shared_ptr<std::array<baf::KnotVector, 2>> knot_vector_ptr;
 };
 
 TEST_F(A2DBSpline, Corner) {

--- a/test/b_spline_test.cc
+++ b/test/b_spline_test.cc
@@ -46,11 +46,13 @@ class ABSpline : public Test {
         baf::ControlPoint(std::vector<double>({4.0, 1.5})),
         baf::ControlPoint(std::vector<double>({4.0, 0.0}))
     };
-    b_spline = std::make_unique<spl::BSpline<1>>(knot_vector, degree, control_points);
+    knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 1>>(knot_vector);
+    b_spline = std::make_unique<spl::BSpline<1>>(knot_vector_ptr, degree, control_points);
   }
 
  protected:
   std::unique_ptr<spl::BSpline<1>> b_spline;
+  std::shared_ptr<std::array<baf::KnotVector, 1>> knot_vector_ptr;
 };
 
 TEST_F(ABSpline, Returns0_0For0AndDim0) {

--- a/test/nurbs_2_d_test.cc
+++ b/test/nurbs_2_d_test.cc
@@ -40,7 +40,8 @@ class A2DNurbs : public Test {
         baf::ControlPoint(std::vector<double>({2.5, 3.5})),
         baf::ControlPoint(std::vector<double>({5.0, 2.0}))
     };
-    nurbs_ = std::make_unique<spl::NURBS<2>>(knot_vector, degree, control_points, weights);
+    std::shared_ptr<std::array<baf::KnotVector, 2>> knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 2>>(knot_vector);
+    nurbs_ = std::make_unique<spl::NURBS<2>>(knot_vector_ptr, degree, control_points, weights);
   }
 
  protected:
@@ -133,8 +134,9 @@ class A2DNurbsWithAllWeights1 : public Test {
         baf::ControlPoint(std::vector<double>({2.5, 3.5})),
         baf::ControlPoint(std::vector<double>({5.0, 2.0}))
     };
-    nurbs_ = std::make_unique<spl::NURBS<2>>(knot_vector, degree, control_points, weights);
-    bspline_ = std::make_unique<spl::BSpline<2>>(knot_vector, degree, control_points);
+    std::shared_ptr<std::array<baf::KnotVector, 2>> knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 2>>(knot_vector);
+    nurbs_ = std::make_unique<spl::NURBS<2>>(knot_vector_ptr, degree, control_points, weights);
+    bspline_ = std::make_unique<spl::BSpline<2>>(knot_vector_ptr, degree, control_points);
   }
 
  protected:

--- a/test/nurbs_3_d_test.cc
+++ b/test/nurbs_3_d_test.cc
@@ -45,8 +45,9 @@ class A3DNurbsWithAllWeights1 : public Test {
         baf::ControlPoint(std::vector<double>({2.5, 3.5})),
         baf::ControlPoint(std::vector<double>({5.0, 2.0}))
     };
-    nurbs_ = std::make_unique<spl::NURBS<3>>(knot_vector, degree, control_points, weights);
-    bspline_ = std::make_unique<spl::BSpline<3>>(knot_vector, degree, control_points);
+    std::shared_ptr<std::array<baf::KnotVector, 3>> knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 3>>(knot_vector);
+    nurbs_ = std::make_unique<spl::NURBS<3>>(knot_vector_ptr, degree, control_points, weights);
+    bspline_ = std::make_unique<spl::BSpline<3>>(knot_vector_ptr, degree, control_points);
   }
 
  protected:

--- a/test/nurbs_test.cc
+++ b/test/nurbs_test.cc
@@ -35,7 +35,8 @@ class NurbsEx4_1 : public Test {
         baf::ControlPoint(std::vector<double>({4.0, 1.0})),
         baf::ControlPoint(std::vector<double>({5.0, -1.0}))
     };
-    nurbs = std::make_unique<spl::NURBS<1>>(knot_vector, degree, control_points, weights);
+    std::shared_ptr<std::array<baf::KnotVector, 1>> knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 1>>(knot_vector);
+    nurbs = std::make_unique<spl::NURBS<1>>(knot_vector_ptr, degree, control_points, weights);
   }
 
  protected:
@@ -68,7 +69,8 @@ class ANurbs : public Test {
         baf::ControlPoint(std::vector<double>({6.0, 4.0, 5.3})),
         baf::ControlPoint(std::vector<double>({8.5, 4.5, 0.0}))
     };
-    nurbs = std::make_unique<spl::NURBS<1>>(knot_vector, degree, control_points, weights);
+    std::shared_ptr<std::array<baf::KnotVector, 1>> knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 1>>(knot_vector);
+    nurbs = std::make_unique<spl::NURBS<1>>(knot_vector_ptr, degree, control_points, weights);
   }
 
  protected:
@@ -114,7 +116,8 @@ class NurbsDerivativeEx4_2 : public Test {
         baf::ControlPoint(std::vector<double>({1.0, 1.0})),
         baf::ControlPoint(std::vector<double>({0.0, 1.0}))
     };
-    nurbs = std::make_unique<spl::NURBS<1>>(knot_vector, degree, control_points, weights);
+    std::shared_ptr<std::array<baf::KnotVector, 1>> knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 1>>(knot_vector);
+    nurbs = std::make_unique<spl::NURBS<1>>(knot_vector_ptr, degree, control_points, weights);
   }
 
  protected:

--- a/test/projection_curve_test.cc
+++ b/test/projection_curve_test.cc
@@ -24,12 +24,12 @@ using testing::DoubleNear;
 class ABSpline2 : public Test {
  public:
   ABSpline2() {
-    knot_vector =
+    std::array<baf::KnotVector, 1> knot_vector =
         {baf::KnotVector({ParamCoord{0}, ParamCoord{0}, ParamCoord{0}, ParamCoord{0}, ParamCoord{0.2}, ParamCoord{0.4},
                           ParamCoord{0.6}, ParamCoord{0.8}, ParamCoord{1}, ParamCoord{1}, ParamCoord{1},
                           ParamCoord{1}})};
-    degree = {3};
-    control_points = {
+    std::array<int, 1> degree = {3};
+    std::vector<baf::ControlPoint> control_points = {
         baf::ControlPoint(std::vector<double>({100, 100})),
         baf::ControlPoint(std::vector<double>({140, 196})),
         baf::ControlPoint(std::vector<double>({200, 240})),
@@ -39,28 +39,26 @@ class ABSpline2 : public Test {
         baf::ControlPoint(std::vector<double>({460, 196})),
         baf::ControlPoint(std::vector<double>({500, 100}))
     };
+    knot_vector_ptr = std::make_shared<std::array<baf::KnotVector, 1>>(knot_vector);
+    b_spline = new spl::BSpline<1>(knot_vector_ptr, degree, control_points);
   }
 
  protected:
-  std::array<baf::KnotVector, 1> knot_vector;
-  std::array<int, 1> degree;
-  std::vector<baf::ControlPoint> control_points;
+  spl::BSpline<1> *b_spline;
+  std::shared_ptr<std::array<baf::KnotVector, 1>> knot_vector_ptr;
 };
 
 TEST_F(ABSpline2, CloseToCenter) {
-  ASSERT_THAT(spl::Projection<1>::ProjectionOnSpline({332, 200},
-                                                     new spl::BSpline<1>(knot_vector, degree, control_points))[0],
+  ASSERT_THAT(spl::Projection<1>::ProjectionOnSpline({332, 200}, b_spline)[0],
               DoubleNear(0.6223419238, 0.0001));
 }
 
 TEST_F(ABSpline2, RightOfLastKnot) {
-  ASSERT_THAT(spl::Projection<1>::ProjectionOnSpline({800, 200},
-                                                     new spl::BSpline<1>(knot_vector, degree, control_points))[0],
+  ASSERT_THAT(spl::Projection<1>::ProjectionOnSpline({800, 200}, b_spline)[0],
               DoubleEq(1));
 }
 
 TEST_F(ABSpline2, LeftOfFirstKnot) {
-  ASSERT_THAT(spl::Projection<1>::ProjectionOnSpline({0, 0},
-                                                     new spl::BSpline<1>(knot_vector, degree, control_points))[0],
+  ASSERT_THAT(spl::Projection<1>::ProjectionOnSpline({0, 0}, b_spline)[0],
               DoubleEq(0));
 }


### PR DESCRIPTION
For the creation of a spline, you need to pass a shared pointer to
the constructor. This effects all tests, as well as all functions that
derive from spline.h. The square generator is modified so that the
constructor is explicit now.