### PR TITLE
Fix the issue of including external files in coverage report

### DIFF
--- a/scripts/docker/Dockerfile.test.coverage
+++ b/scripts/docker/Dockerfile.test.coverage
@@ -23,7 +23,8 @@ lcov --remove coverage.info '*/CMakeFiles/*' --output-file coverage.info && \
 lcov --remove coverage.info '*/external/*' --output-file coverage.info && \
 lcov --list coverage.info && \
 find . -name "*.gcov" -type f -delete && \
-find . -name "*.gcda" -type f -delete
+find . -name "*.gcda" -type f -delete && \
+find . -name "*.gcno" -type f -delete
 
 # Set-up shell
 SHELL ["bash", "-c"]


### PR DESCRIPTION
```lcov``` creates additional ```*.gcno``` files that were left in the image. These files were read by codecov.io. After deleting these files, only ```coverage.info``` should be read.